### PR TITLE
A quick fix of lazy I/O

### DIFF
--- a/src/OrderOrder.hs
+++ b/src/OrderOrder.hs
@@ -36,7 +36,7 @@ extractImport ("import" : name : _) = [name]
 extractImport _ = []
 
 getImports :: FilePath -> IO [String]
-getImports path = concatMap extractImport . map words . lines <$> readFile path
+getImports path = concatMap extractImport . map words . lines . B.unpack <$> B.readFile path
 
 getEntry :: FilePath -> FilePath -> IO Graph
 getEntry prefix path = do


### PR DESCRIPTION
I ran into 
``` bash
orderorder: .....: openFile: resource exhausted (Too many open files)
```
when running `OrderOrder` on a source directory containing 1600+ lines of source files. It seems to be caused by the lazy I/O behaviour of `System.IO.readFile` (similar issue here https://github.com/haskell/cabal/issues/5115).

I gave it a quickfix and it's no longer an error.